### PR TITLE
Fix for title encoding & URLs

### DIFF
--- a/giant_bomb_cli.py
+++ b/giant_bomb_cli.py
@@ -28,6 +28,7 @@ CONFIG_LOCATION = os.path.expanduser("~/.giant_bomb_cli")
 
 def gb_log(colour, string):
     " Log a string with a specified colour "
+    string = string.encode('utf-8')
     print colour + string + COLOURS["End"]
 
 def file_exists_on_server(url):
@@ -178,7 +179,7 @@ def download_video(url, filename):
 
     gb_log(COLOURS["Title"], "Downloading " + url + " to " + filename)
     try:
-        call(["wget", "--user-agent", "downloading via giant_bomb_cli",
+        call(["wget", "--no-check-certificate", "--user-agent", "downloading via giant_bomb_cli",
               url + "?api_key=" + get_api_key(), "-c", "-O", filename])
     except OSError:
         gb_log(COLOURS["Error"],
@@ -189,7 +190,9 @@ def output_response(response, args, download_archive):
 
     for video in response["results"]:
         name = video["name"]
+        name = name.replace(u"\u2018", "'").replace(u"\u2019", "'")
         desc = video["deck"]
+        desc = desc.replace(u"\u2018", "'").replace(u"\u2019", "'")
         time_in_secs = video["length_seconds"]
         video_id = video["id"]
         url = video[args.quality + "_url"]
@@ -202,16 +205,18 @@ def output_response(response, args, download_archive):
                u"{0} ({1}) [{2}] ID:{3}".format(name, video_show_string,
                                                 convert_seconds_to_string(time_in_secs),
                                                 video_id))
-        gb_log(COLOURS["Desc"], "\t" + desc)
+#        gb_log(COLOURS["Desc"], "\t" + desc)
 
         if args.shouldStream:
             stream_video(url)
         elif args.shouldDownload:
-            # Construct filename
-            filename = name.replace(" ", "_")
-            filename = filename.replace("/", "-")
+          # Construct filename
+            filename = name.replace("/", "-")
             filename = filename.replace(":", "")
-            filename += "." + url.split(".")[-1]
+            if url is not None:
+            	filename += "." + url.split(".")[-1]
+            filename = str(video_id) + " - " + filename
+            filename = filename.replace(u"\u2018", "'").replace(u"\u2019", "'").replace(u"\xe9", "e")
 
             if args.outputFolder != None:
                 if not os.path.exists(args.outputFolder):

--- a/giant_bomb_cli.py
+++ b/giant_bomb_cli.py
@@ -190,9 +190,9 @@ def output_response(response, args, download_archive):
 
     for video in response["results"]:
         name = video["name"]
-        name = name.replace(u"\u2018", "'").replace(u"\u2019", "'")
+        name = name.replace(u"\u2018", "'").replace(u"\u2019", "'").replace(u"\xe9", "e")
         desc = video["deck"]
-        desc = desc.replace(u"\u2018", "'").replace(u"\u2019", "'")
+        desc = desc.replace(u"\u2018", "'").replace(u"\u2019", "'").replace(u"\xe9", "e")
         time_in_secs = video["length_seconds"]
         video_id = video["id"]
         url = video[args.quality + "_url"]

--- a/giant_bomb_cli.py
+++ b/giant_bomb_cli.py
@@ -131,6 +131,8 @@ def dump_video_shows(api_key):
         return 1
 
     for video_show in json_obj["results"]:
+	video_show["title"] = video_show["title"].replace(u"\u2018", "'").replace(u"\u2019", "'").replace(u"\xe9", "e")
+	video_show["deck"] = video_show["deck"].replace(u"\u2018", "'").replace(u"\u2019", "'").replace(u"\xe9", "e")
         gb_log(COLOURS["Desc"],
                "\t {0}: {1} - ({2})".format(video_show["id"],
                                             video_show["title"], video_show["deck"]))

--- a/giant_bomb_cli.py
+++ b/giant_bomb_cli.py
@@ -231,7 +231,7 @@ def output_response(response, args, download_archive):
 
             download_video(url, filename)
 
-            if args.downloadArchive:
+            if args.downloadArchive and url is not None:
                 download_archive["Downloaded"].append(video_id)
 
     if len(response["results"]) == 0:


### PR DESCRIPTION
Hi, I was able to fix my issues with utf8 encoded characters in the titles of videos, by basically performing a crude replace of the characters with an ascii version. 
I don't know python at all, so it's a very hacky way to get around it, there's probably a much better way to handle encoding, but it works so far for me.

I've also fixed the issue where the API would sometimes return an empty URL or something like that. This is checked for in parts of the code, but isn't when constructing the filename, and, filename += "." + url.split(".")[-1] causes an error.
Again, I've put in a very hacky solution to just bypass that line if the URL is empty.

These changes should solve (poorly!) both of the issues currently open.